### PR TITLE
English spelling, typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Source of the Privacy by Design Foundation's website
 
-This Jekyll website, based on the [Feeling Responsive theme](https://https://github.com/Phlow/feeling-responsive), is the source of <https://privacybydesign.foundation>.
+This Jekyll website, based on the [Feeling Responsive theme](https://github.com/Phlow/feeling-responsive), is the source of <https://privacybydesign.foundation>.

--- a/pages/en/irma-en.md
+++ b/pages/en/irma-en.md
@@ -19,13 +19,13 @@ To get a quick *hands-on* impression of IRMA:
   * [fill](/issuance) this app with various personal attributes;
 
   * [try out](/demo-en) some of the IRMA demo applications, for
-    logging in with attributes, automatic form-filling, and digitale
+    logging in with attributes, automatic form-filling, and digital
     signatures.
 
 IRMA offers a way for privacy-friendly authentication. When
 authenticating, you as a user reveal only relevant properties
 (attributes) of yourself, using an IRMA app on your mobile phone ---
-for instane that you are older than 16. In addition, with this app you
+for instance that you are older than 16. In addition, with this app you
 can also digitally sign messages, where you identify yourself as a
 signer also with personal attributes. In this way you can sign for
 instance with your name and address, or with your medical
@@ -45,10 +45,10 @@ if you do not wish to disclose anything else.
     and delete all your attributes. You can do all this free of
     charge.
 
-    You can [try out](/demo-en) IRMA yourself, but can also readd more
+    You can [try out](/demo-en) IRMA yourself, but can also read more
     about IRMA first, at [this page](/irma-explanation).
 
- 2. I'm from a **webshop** or another **organisation** that may want
+ 2. I'm from a **webshop** or another **organization** that may want
     to use IRMA in order to let customers/members log in
     (authenticate), or to register consent from customers via a
     digital signature, in accordance with the General Data Protection

--- a/pages/en/irma-explanation.md
+++ b/pages/en/irma-explanation.md
@@ -9,7 +9,7 @@ translations:
   nl: /irma-uitleg
 ---
 
-<a name="top"></a> This page explains the ideas behind the idenity
+<a name="top"></a> This page explains the ideas behind the identity
 platform IRMA.  It also explains how the system works and has been
 designed. The following topics will be discussed.
 
@@ -48,13 +48,13 @@ privacy-protection is intrinsic to the system, which is called
 regulation such privacy by design is legally required for new
 ICT-systems.
 
-Apart from instrinsic privacy-protection, IRMA also protects against
+Apart from intrinsic privacy-protection, IRMA also protects against
 identity fraud: if your name and date of birth are not revealed at
 all, they cannot be abused.
 
 The list below gives several examples of attributes that may be useful,
 for instance for interaction with a webshop, with the government,
-with your bank, or at a webforum, etc.
+with your bank, or at a web-forum, etc.
 
 * I'm a student (or a pensioner)
 * I'm older than 12 (or 16, or 18, or 21, or 65)
@@ -69,7 +69,7 @@ with your bank, or at a webforum, etc.
 * My email address is ...
 * My mobile phone number is ...
 * My loyalty card of company X has status bronze / silver / gold
-* My rail subscribtion is first / second class
+* My rail subscription is first / second class
 * etc. etc.
 
 Some of these attributes are uniquely identifying, like your bank
@@ -110,7 +110,7 @@ non-digital world we rely very much on context: the person wears a
 white coat and receives you in an office in a building that says
 "hospital" above it entrance. But in the online world such context
 information is often missing (or is easy to fabricate), so that we
-have to use attributes like in IRMA for trusted intraction.
+have to use attributes like in IRMA for trusted interaction.
 
 [To the top](#top)
 
@@ -119,7 +119,7 @@ have to use attributes like in IRMA for trusted intraction.
 The short answer is: attributes protect you and empower you.
 
 Via a unique personal number, like a passport number or a national
-registration number, people can be recognised in many different
+registration number, people can be recognized in many different
 situations and all their actions can be linked. This has many
 advantages, for instance in public services. But it can also have
 serious disadvantages, especially when this unique personal number is
@@ -132,30 +132,30 @@ cannot be stolen. In this sense, attributes protect you.
 
 Usage of attributes, instead of identities, has additional advantages.
 
-* It is privacy-friendly because of *data minimalisation*. Only those
+* It is privacy-friendly because of *data minimization*. Only those
   attributes which are relevant and necessary for a transaction need
   to be disclosed.
 * It provides the user, at least with IRMA, real control and
-  transparancy about who is requesting to see which attributes.
+  transparency about who is requesting to see which attributes.
 * It is flexible and can be used in many situations.
 * It prevents linking of different transactions, as long as
   non-identifying attributes are being used. Hence it also prevents
-  open or surreptitious surrveillance and profiling, and everything
+  open or surreptitious surveillance and profiling, and everything
   that is associated with it, such as price-discrimination (the price
   that you have to pay depends on the profile that has been assembled
   about you).
 
-In many digitisation projects of the past decades attributes from
+In many digitization projects of the past decades attributes from
 daily life have been replaced by digital identities. An example is
 smart card based e-ticketing in public transport. Traditionally,
 having a (anonymous, untraceable) paper ticket was enough to get on a
 bus or train. These days one implicitly reveals one's identity by
 using a (uniquely numbered) smart card. Via such cards individual
 movements can be traced and stored for many years, be used for
-marketing purposes, and posssibly become public through a computer
+marketing purposes, and possibly become public through a computer
 hack or through negligence. Anonymous cards, at least in the
 Netherlands, do not offer much privacy protection, since when an error
-needs to be corrected or when you want to receive any remaining saldo
+needs to be corrected or when you want to receive any remaining balance
 on the card after its expiration, you need to disclose your
 identity. In this way a connection is made between you and and all
 your travels, which, you thought, were anonymous.
@@ -184,7 +184,7 @@ banking have their own PIN.
 Attributes that hold for you can be downloaded to your IRMA app on
 your phone. Typically this is done via the [web](/issuance), but it is
 also possible to do this in a face-to-face scenario at a counter. An
-organisation that provides attributes is called an *attribute issuer*,
+organization that provides attributes is called an *attribute issuer*,
 or simply an *issuer*. There may be several issuers of attributes, such
 as:
 
@@ -197,16 +197,16 @@ as:
   addresses, phone numbers, IP-addresses
 * the Facebook's / Google's / Apple's / Amazon's / Microsoft's of this
   world for login data
-* big or small webshops, with loyaly cards and custum numbers, with
+* big or small web-shops, with loyalty cards and custom numbers, with
     associated status, coupons, etc.
-* companies and other organisations, for attributes as a basis for
+* companies and other organizations, for attributes as a basis for
   fine-grained role-based access management
-* hospitals and other healthcare organisations, for regulating access
+* hospitals and other healthcare organizations, for regulating access
   via attributes, not only for healthcare professionals, but also for
   patients
 * block chain initiatives, for authentication of users and their roles
-* military organisations, for all their different ranks and (security)
-  compartimentalisations and clearances, and for members of special
+* military organizations, for all their different ranks and (security)
+  compartmentalizations and clearances, and for members of special
   forces whose identifying data are typically not revealed
 * etc.
 
@@ -241,10 +241,10 @@ a *verifier*, or sometimes a *relying party*. There is a special
 It is built into the IRMA system that these verifiers must make very
 clear to you which attributes they request to see.  You, as an IRMA
 user, have to explicitly agree to the release of those attributes.  In
-this way it is clear and transparant who wants to know what about you.
+this way it is clear and transparent who wants to know what about you.
 The IRMA app keeps its own log, so that you can see later which verifier
 has requested which attributes (at what time), and what you have
-revealed. If there are verifiers who request disproportionally much
+revealed. If there are verifiers who request disproportionately much
 information from users, you can file a complaint, based on these logs,
 for instance with your (national) data protection authority.
 
@@ -265,7 +265,7 @@ attributes is much simpler, however, since it can be done online.
 
 The three pictures below give a schematic overview, first of
 downloading attributes at an issuer, and subsequently, of
-using attributes at two different webshops.
+using attributes at two different web-shops.
 <hr>
 <p align="center"><img src="../images/Transactions_IRMA_voorbereiding_en.png" alt="IRMA uitgever" style="width: 55%; height: 55%"/></p>
 <hr>
@@ -313,7 +313,7 @@ IRMA differs in essential ways from other identity management systems,
 such as [Facebook
 login](https://developers.facebook.com/docs/facebook-login), or
 [iDIN](http://www.idin.nl) in the Netherlands. IRMA has a
-*decentralised* architecture. Your attributes are stored only locally,
+*decentralized* architecture. Your attributes are stored only locally,
 on your phone, and not centrally in the computer systems of some
 "identity broker". When you use IRMA to prove to a webshop that you
 are older than 18, your IRMA app communicates directly with the
@@ -332,10 +332,10 @@ wish to login at X. After logging into Facebook, using your Facebook
 credentials, Facebook gives website X certain information about
 you. In this way Facebook learns where you login at what moment and
 uses this information to extend your profile and adapt its
-advertisement targeting. In addition, it is not transparant to you
+advertisement targeting. In addition, it is not transparent to you
 which data about you website X receives from Facebook.
 
-Many identity management systems are organised in such a *centralised*
+Many identity management systems are organized in such a *centralized*
 manner. This is commercially most interesting for the providers of the
 identity management system: they can not only build up and sell
 profiles of all users --- who logs in where and when with which data
@@ -349,23 +349,23 @@ can see whether you login to a liquor store or to a psychiatric
 clinic. The banks [promise](https://www.idin.nl/consumenten) that they
 will not use this information for other purposes, for instance, when
 they decide whether or not you will get a mortgage. In IRMA's
-decentralised architecture such uncomfortable issues do not arise at
-all. In addition, relying parties, such as webshops, need to pay the
+decentralized architecture such uncomfortable issues do not arise at
+all. In addition, relying parties, such as web-shops, need to pay the
 banks per iDIN authentication session. The prices are a real concern
 for them, and have already led to complaints. Again, with IRMA there
-are no such artificial costs imposed by the chosen (centralised)
+are no such artificial costs imposed by the chosen (centralized)
 architecture.
 
-The difference between a decentralised (IRMA) and centralised
+The difference between a decentralized (IRMA) and centralized
 (non-IRMA) set-up is sketched below.
 <p align="center"><img src="../images/Transactions_all_lowres_en.png" alt="overzicht" style="width: 100%; height: 100%"/></p>
 
 It may be clear that in the non-IRMA set-up the issuer of attributes
 is a *privacy hotspot* who facilitates and sees all
-transactions. Moreover, in the centralised architecture a (malicious)
+transactions. Moreover, in the centralized architecture a (malicious)
 issuer can completely take over your identity and impersonate you. You
 have no way to stop this, or even notice it --- until possibly later
-when you are confronted with the consequences. In the decentralised
+when you are confronted with the consequences. In the decentralized
 IRMA set-up you have genuine control over the usage of your own
 attributes: you directly disclose your own attributes yourself, every
 time only after explicit consent, without (unnecessary) interference
@@ -374,12 +374,12 @@ of third parties.  This is similar to the way you can disclose your
 
 In the IRMA system there are no such *privacy hotspots*. At a
 meta-level, IRMA does involve some level of coordination about how
-attributes and credentials are organised and which cryptographic
+attributes and credentials are organized and which cryptographic
 (public) keys are needed at which stage. This coordinating role is
 fulfilled by the Privacy by Design foundation. But: the foundation can
 not see at all which attributes are used where.
 
-The Privacy by Design foundation does not monopolise IRMA and its
+The Privacy by Design foundation does not monopolize IRMA and its
 technology. The software is open source and is freely available, for
 everyone to use. Also other parties can play the coordinating and/or
 issuing roles that the foundation is playing at this stage.  In fact,
@@ -388,22 +388,22 @@ register](/issuance-big) would directly issue IRMA attributes
 themselves, instead of the foundation doing so indirectly ---
 currently, hopefully temporarily.
 
-Decentralised and centralised identity management systems do not
+Decentralized and centralized identity management systems do not
 exclude each other. In fact, they can work well together, for instance
 in the case of iDIN providing attributes for IRMA. IRMA can best be
 used for applications where privacy plays a (big) role and where
-attributes are needed that can not be organised easily in a
-centralised manner, for instance because of legal restrictions or lack
+attributes are needed that can not be organized easily in a
+centralized manner, for instance because of legal restrictions or lack
 of trust in central storage among users. IRMA can also handle
 "temporary" attributes, like an entry ticket for a concert, containing
 the name, date and location of the concert. In principle, you can buy
 such a ticket online and download it as attribute to your IRMA app. At
 the entrance of the concert you can disclose the ticket for
 verification, and subsequently delete it from your phone. (Such
-tickets are strictly personal non-transferrable, because they are
+tickets are strictly personal non-transferable, because they are
 cryptographically connected to your own personal IRMA app.)
 
-A subtle point is wheter IRMA outperforms centralised architectures
+A subtle point is whether IRMA outperforms centralized architectures
 since such architectures intrinsically have a single-point-of-failure;
 if it goes down all authentication is disabled. In fact, IRMA also
 involves a small central *keyshare* component, as will be explained in
@@ -488,9 +488,9 @@ party*). Such a verifier checks a number of things:
 
 The Privacy by Design foundation has freely available open source
 [software](https://credentials.github.io/) also for this verifier
-role.  It allows a webshop, or other organisation, to verify
+role.  It allows a webshop, or other organization, to verify
 attributes from its customers, see the [more detailed
-explanations](/irma-verifier) elsewhere. Small webshops may wish to
+explanations](/irma-verifier) elsewhere. Small web-shops may wish to
 outsource such attribute verifications to third parties, just like
 they often outsource payment processing. This is possible, but is not
 ideal for privacy, since these external verifiers see many
@@ -499,7 +499,7 @@ as a commercial service.
 
 Credentials are cryptographically bound to a mobile phone, and to each
 other, via a personal secret cryptographic key. This private key is
-crucial for the security of the IRMA app; it must be stored securily.
+crucial for the security of the IRMA app; it must be stored securely.
 Such secure local storage is difficult on a mobile phone, since the
 device may be rooted or hacked. That is why a small but crucial part
 of this private key is stored outside the phone on a so-called
@@ -545,7 +545,7 @@ IP-address involved, or the "fingerprint" of the browser. The above
 webshop may conclude, rightly or not, that the same person is involved
 because both attribute disclosures come from the same IP-address.
 
-Protection against this is possible, for instance via anonymisation
+Protection against this is possible, for instance via anonymization
 technologies, such as [Tor](https://www.torproject.org). But such
 protection is not built into IRMA.
 
@@ -559,40 +559,40 @@ relations in society.  In general, the more powerful parties impose
 authentication requirements and mechanisms on the less powerful
 parties. The Privacy by Design foundation is well aware of these
 societally important issues and aims to use value-laden design in
-offering IRMA as a transparant open identity platform for proportional
+offering IRMA as a transparent open identity platform for proportional
 and contextual authentication that empowers, instead of weakens,
 users. This context-dependence is related to [Helen
 Nissenbaum](http://www.nyu.edu/projects/nissenbaum/)'s interpretation
-of privacy as contextuele integrity.
+of privacy as contextual integrity.
 
 IRMA works via freely available open source software. Everyone can
 inspect and judge how it works. This contributes to confidence, not
 only in the proper functioning of the IRMA system, but also in order
-to check that there are no hidden backdoors in the system.  Such
-transparancy is essential for broad voluntary usage and acceptance of
+to check that there are no hidden back-doors in the system.  Such
+transparency is essential for broad voluntary usage and acceptance of
 sensitive ICT-infrastructure, like for authentication. With IRMA there
-is no commerical lock-in, and there is no extorted trust. Even if the
+is no commercial lock-in, and there is no extorted trust. Even if the
 foundation somehow goes down, the IRMA software will still be there
 and can be maintained and continued by others.
 
 Thus, IRMA is not about plundering or deceiving users, or about
 surreptitiously steering them commercially or politically, but about
-encountering them transparantly, with dignity, respecting their
+encountering them transparently, with dignity, respecting their
 autonomy and privacy.
 
 IRMA is based on properties of individuals (attributes) whose source
 is explicitly visible, namely in the form of the issuer who commits
-itself via digitial signatures to the validity of these attributes.
+itself via digital signatures to the validity of these attributes.
 IRMA is thus about "objective" properties and qualifications of people,
 where the objectivity lies in the verifiable origin of attributes.
 In this way IRMA distinguishes itself from "subjective" reputation-based
 systems, in which qualifications can be manipulated relatively
-easilty and their origin is seldomly transparent.
+easily and their origin is seldom transparent.
 
 IRMA does not exclude commercial activities surrounding
 authentication. But these commercial activities work best *on top of*
 an open basic infrastructure, and not in its core.  Internet protocols
-like TCP and IP are also open, and form the basis for the succes of
+like TCP and IP are also open, and form the basis for the success of
 the internet, together with all the commercial transactions that run
 on top of TCP/IP.
 
@@ -619,27 +619,27 @@ strongly bound to an individual via a certificate that contains the
 associated public key. Digital signatures that satisfy certain
 requirements have a legal status.
 
-A big disadvantage of both tranditional and current digital signatures
+A big disadvantage of both traditional and current digital signatures
 is that they give very little information about who precisely signs,
 in which capacity.
 
-An attribute-based signature is a special digital signature in wich
+An attribute-based signature is a special digital signature in which
 the attachment to the document securely contains a number of
 attributes of the signer. These attributes are visible to everyone who
 checks the signature. In this way you can see for instance that a
-written account of ilness has actually been signed by a medical
+written account of illness has actually been signed by a medical
 doctor, via the "medical doctor" attribute, possibly combined with the
-signer's medical specialisation. Another example is a request from a
+signer's medical specialization. Another example is a request from a
 citizen to the authorities, say about some permit, which is signed
 with the citizen's own national registration number included as
-attribute. In this way the authorities recognise that the request
+attribute. In this way the authorities recognize that the request
 really comes from a particular citizen. Also payment orders can be
-realised via attribute-based signatures, by including the bank account
+realized via attribute-based signatures, by including the bank account
 number of the signer as attribute in the signature.
 
 Attribute-based signatures are supported by the IRMA
 software. Attribute-based signatures form a novel concept with
-unprecented application possiblities.
+unprecedented application possibilities.
 
 [To the top](#top)
 
@@ -674,7 +674,7 @@ be an advantage.
 However, the identity platform IRMA is economically viable. Issuance
 and verification of attributes may form a commercial service, which
 can be performed by third parties. Also, the Privacy by Design
-foundation may issue certain specialised credentials for a
+foundation may issue certain specialized credentials for a
 fee. Possibly, in order to maintain its activities in the long-term
 future, the foundation may start charging IRMA users, for instance a
 couple of Euros per year, for a basic set of attributes.
@@ -690,19 +690,19 @@ applications. Several parties are currently working on this.
 
 Do you value careful, privacy-friendly interaction with your
 customers, and do you have a good idea for an IRMA application,
-for instance in your webshop or within your organisation, do
+for instance in your webshop or within your organization, do
 [contact](/contact-en) the Privacy by Design foundation.
 For instance, the foundation can:
 
-* advice about the organisation of attributes for the intended application;
+* advice about the organization of attributes for the intended application;
 * advice about the usage of the open source software of the foundation;
 * possibly extend this software for optimal use within your
   application; such extensions will in principle also be open source
   and be available for others.
 
-The foundation may aks a to-be-determined financial contribution for
+The foundation may ask a to-be-determined financial contribution for
 such advice, in order to maintain its own activities. The foundation
-is a not-for-profit organisation, without commercial targets.
+is a not-for-profit organization, without commercial targets.
 
 Even if you do not have a concrete application in mind, but wish to
 contribute to the IRMA development, via your efforts or via a

--- a/pages/en/irma-start.md
+++ b/pages/en/irma-start.md
@@ -23,7 +23,7 @@ Deze pagina geeft antwoord op de volgende vragen.
 
 ### <a name="getstarted"></a>1. How to get started with IRMA
 
-The next diagram summarises the initial steps, when you wish to start
+The next diagram summarizes the initial steps, when you wish to start
 using IRMA.
 
 <p align="center"><img src="../images/Registratie_Stappenplan_en.png" alt="IRMA issuer" style="width: 50%; height: 50%"/></p>
@@ -73,8 +73,8 @@ registration at the foundation, on the [MyIRMA](/myirma) webpage.
 [Below](#myirma) more information will be given about this.  Adding an
 email address is optional, not compulsory. If you do not add it, the
 foundation knows nothing about you except an automatically generated
-random username. You can see this username, after succesful
-registation, by tapping on "MyIRMA login" in the attributes overview
+random username. You can see this username, after successful
+registration, by tapping on "MyIRMA login" in the attributes overview
 in your IRMA app.
 
 When you choose to associate an email address to your account, please
@@ -88,16 +88,16 @@ In exceptional cases the email address may be used to contact you
 about usage of IRMA. The address is not shared with anyone else.
 
 
-#### 1.3. Personalisation with your email address
+#### 1.3. Penalization with your email address
 
 The email address that you possibly submit upon registration can now
 be loaded into your IRMA app on your phone. After the previous
 registration steps, in which you have chosen your PIN code and email
-address, you will receive a link (webaddress) by email. By clicking on
+address, you will receive a link (web-address) by email. By clicking on
 this link and following subsequent instructions, your email address
 will be added as attribute in your IRMA app.
 
-When you go in a webbrowser to the webaddress in this link (received
+When you go in a web-browser to the web-address in this link (received
 by email), you will see an "Email Issue" button. It illustrates how
 issuing and receiving of attributes works.
 
@@ -116,12 +116,12 @@ issuing and receiving of attributes works.
 After registration you can try out the [IRMATube demo](/demo/irmaTube).
 
 
-#### 1.4. Personalisation with additional attributes
+#### 1.4. Penalization with additional attributes
 
 It is possible to receive more attributes, in addition to your email
 address. You can do this immediately upon registration, but also
 later. To do so, please visit the [IRMA issuance](/issuance) page.
-There you will see several possiblities to load additional attributes.
+There you will see several possibilities to load additional attributes.
 This list of possibilities is not fixed, and will grow in the future,
 as more parties join IRMA. At this stage the focus is on attributes
 from Dutch sources. If you wish to join with other, possibly
@@ -163,7 +163,7 @@ possibilities.
   there that your app is being used while you know nothing about it,
   something is wrong: someone else may be abusing your app in order to
   steal your identity. This is a reason to take action immediately. It
-  brings us to the second possiblity that the myIRMA webpage offers.
+  brings us to the second possibility that the myIRMA webpage offers.
 
 * At the MyIRMA webpage you can disable (block) further usage of your
   IRMA app. Of course, you can do this at any moment when you no
@@ -202,7 +202,7 @@ The text below dives deeper into what precisely happens when you
 register via the IRMA app. This background information is not
 necessary for actual usage of IRMA; it is intended for people who are
 more technically interested and like to know how things have been set
-up and how security and privacy-protection have been organised in the
+up and how security and privacy-protection have been organized in the
 IRMA ecosystem. Even more information is available on a [separate
 page](/irma-explanation).
 
@@ -235,7 +235,7 @@ email. Hence he/she can log into your MyIRMA account. But the only
 thing that the thief can do there is disable your account. Hopefully,
 by then, you have already done this yourself.
 
-To summarise: the MyIRMA server offers additional protection and
+To summarize: the MyIRMA server offers additional protection and
 inspection, but cannot do anything on its own --- except disable.  The
 Privacy by Design foundation operates the MyIRMA server in order enable
 the usage of IRMA. In principle, other parties can run such a server
@@ -254,7 +254,7 @@ When you log into your app with your PIN code, the app computes the
 (large) number *hash( PIN | nonce )*, sends this hash value to the
 MyIRMA server, and deletes your PIN from its memory. If the hash value
 matches the number that the server stores for you, the app and server
-are connected, and your login has succeeded. A succesful attacker
+are connected, and your login has succeeded. A successful attacker
 can possibly extract the nonce from your IRMA app, but that is not
 so useful. The only thing that the attacker can do is try out all
 100,000 possible PIN codes: for each attempt *X*, the number
@@ -262,9 +262,9 @@ so useful. The only thing that the attacker can do is try out all
 server will notice such repeated attempts and will slow down
 the login attempts (*rate limiting*).
 
-The picture below summarises the two roles of the Privacy by Design
+The picture below summarizes the two roles of the Privacy by Design
 foundation. On the one hand, the foundation issues several attributes
-for personalisation of your IRMA app. On the other hand, it operates
+for penalization of your IRMA app. On the other hand, it operates
 the MyIRMA server, for inspection of your own IRMA usage and for
 possibly blocking your account.
 

--- a/pages/en/irma-verifier.md
+++ b/pages/en/irma-verifier.md
@@ -30,7 +30,7 @@ attributes. General explanations about how IRMA works can be found
 [elsewhere](/irma-explanation).
 
  1. [Which attributes of my users can I verify?](#whichattributen)
- 2. [How do I intergrate IRMA software in my webpage?](#software)
+ 2. [How do I integrate IRMA software in my webpage?](#software)
  3. [Can I also issue attributes myself to my customers?](#issue)
  4. [What are the costs of using IRMA?](#costs)
  5. [What level of certainty does IRMA provide?](#level)
@@ -66,32 +66,32 @@ user to a website where the attribute is available. After loading the
 relevant attribute, the user can authenticate at your website.
 
 It is up to you to ask for all sorts of attributes from your users.
-But please be careful: upon loging into your website with IRMA, your
+But please be careful: upon logging into your website with IRMA, your
 customers must explicitly agree to reveal these attributes to you.
-When you ask too many, non-relevant or non-neccessary, attributes, you
+When you ask too many, non-relevant or non-necessary, attributes, you
 may scare away (potential) customers. An important idea underlying
 IRMA is that only strictly necessary attributes should be requested at
-login. European privacy laws require *data minimalisation* and
+login. European privacy laws require *data minimization* and
 *purpose binding*, so that you are allowed to process only those
 personal data of your customers that are strictly necessary for the
 service that you offer.
 
 [To the top](#top)
 
-### <a name="software"></a>2. How do I intergrate IRMA software in my webpage?
+### <a name="software"></a>2. How do I integrate IRMA software in my webpage?
 
 All software for verification of IRMA attributes is open source and
 freely [available](https://credentials.github.io/) to everyone. There
 are several ways to deploy this software.
 
  * If you have ICT skills yourself, or have people with such skills in
-   your organisation, you can install the software on your own
-   computers and integrate it in your webpages.
+   your organization, you can install the software on your own
+   computers and integrate it in your web-pages.
 
  * If your website has been built and is operated by an external
    company, you can ask this company to do the integration for you.
 
- * Possibly, commerical parties will emerge that will offer
+ * Possibly, commercial parties will emerge that will offer
    verification of IRMA attributes as a service.
 
  * In particular, existing *Payment Service Providers* may start
@@ -105,7 +105,7 @@ the foundation can offer advice, but it will not do this
 free-of-charge. For more information, feel free to [get in
 touch](/contact-en).
 
-To summarise: IRMA can be used without any costs, at least if you do
+To summarize: IRMA can be used without any costs, at least if you do
 everything yourself.
 
 The video below provides a tutorial for integrating IRMA attribute
@@ -121,19 +121,19 @@ verification in your website. For more information, see the
 ### <a name="issue"></a>3. Can I also issue attributes myself to my customers?
 
 Suppose you wish to give customers your own attributes, belonging to
-your own organisation, such as membership numbers or specific loyalty
+your own organization, such as membership numbers or specific loyalty
 statuses, like bronze, silver, gold, platinum, etc. This is possible,
 but requires some preparation.
 
 The Privacy by Design foundation runs the IRMA infrastructure. An
 important part of this work is keeping a register of all possible
-attributes. This register must provider transparancy and clarity,
+attributes. This register must provider transparency and clarity,
 so that each user knows the meanings of the various attributes.
 New attributes must become part of this register. It requires
 [contact](/contact-en) with the foundation. The foundation will
 charge for (continued) registration of new attributes.
 
-Once this has been organised, there are several ways to actually issue
+Once this has been organized, there are several ways to actually issue
 attributes to your customers. This involves providing these attributes
 with a digital signature. For this purpose as well open source software
 is freely available. There are several options.
@@ -154,13 +154,13 @@ is freely available. There are several options.
 ### <a name="costs"></a>4. What are the costs of using IRMA?
 
 For the time being the usage of IRMA is free of charge, both for users
-and for verifiers (like webshops). Of course you will have your own
-costs for setting up and maintaining your own webpages in which IRMA
+and for verifiers (like web-shops). Of course you will have your own
+costs for setting up and maintaining your own web-pages in which IRMA
 is integrated. Those costs depend on who does the actual work, in
 which manner, see [above](#software).
 
 The Privacy by Design foundation is a non-profit
-organisation. However, if it comes to large scale usage of IRMA, it is
+organization. However, if it comes to large scale usage of IRMA, it is
 important that the foundation has a stable financial position in order
 to maintain the IRMA infrastructure. As described above, the
 foundation does ask money for certain activities (advice, issuing of
@@ -175,14 +175,14 @@ on subsidies and support of third parties.
 Within the area of *identity management* different assurance levels
 for authentication are distinguished, such as "low", "substantial",
 "high". Often such levels are assigned to specific authentication
-means (such as a chipcard).  Within the IRMA ecosystem assurance
-levels can be assigned to attributes, or, to be more preciese, to
+means (such as a chip-card).  Within the IRMA ecosystem assurance
+levels can be assigned to attributes, or, to be more precise, to
 credentials (sets of attributes). The assurance level of such a
-credential is determined by the manner of authentication that preceeds
+credential is determined by the manner of authentication that precedes
 attribute issuance. The level is for instance *low* for an email
 attribute that has been issued via a confirmation link sent to a
 user-provided email address. The level *substantial* could be assigned
-to an attribute that is issed after e-banking authentication. And the
+to an attribute that is issued after e-banking authentication. And the
 level *high* could be used for attributes that are issued (on the
 spot) only after face-2-face authentication at a counter.
 
@@ -213,7 +213,7 @@ At this stage the foundation offers its operational services for free,
 as "best effort". The foundation offers no guarantees and accepts at
 this stage no liability for matters that possibly go wrong in IRMA
 usage. The foundation tries to solve (reported) problems as soon as
-possible. The responsability for IRMA usage lies entirely with the
+possible. The responsibility for IRMA usage lies entirely with the
 user (the carrier or IRMA attributes), with the verifier of
 attributes, and with the issuer of attributes (if any), not being the
 foundation itself.

--- a/pages/en/issuance-big.md
+++ b/pages/en/issuance-big.md
@@ -26,7 +26,7 @@ issue to you the following attributes:
  * medical specialism
 
 These personal attributes are obtained from the BIG-register.  The
-correctness of the attributes is the register's responsability. The
+correctness of the attributes is the register's responsibility. The
 foundation does not check them.
 
 As first step of this issuance process you disclose your name, date of
@@ -53,7 +53,7 @@ In the current set-up the following rules are used.
 
 * If a BIG registration has expired, no attributes are issued.
 * If multiple people, with both the same name and the same date of
-  birth, occur in the BIG register, no attributes are issed: after
+  birth, occur in the BIG register, no attributes are issued: after
   all, the foundation cannot distinguish these individuals.
 * If someone occurs with multiple medical professions in the BIG
   register, a separate credential is created for each of these

--- a/pages/en/issuance-brp.md
+++ b/pages/en/issuance-brp.md
@@ -46,7 +46,7 @@ The following attributes are issued:
  * birth date
  * age limits (above 12, 16, 18, 21 or 65)
  * sex
- * adress
+ * address
  * zip code
  * city
  * Burger Service Number (BSN).

--- a/pages/en/issuance-email.md
+++ b/pages/en/issuance-email.md
@@ -25,7 +25,7 @@ attribute.
 
 (It appears that in some email clients on mobile phones this link is
 not properly "clickable". In that case you can try to copy the link
-yourself into a webbrowser. Alternatively, you can read this e-mail on
+yourself into a web-browser. Alternatively, you can read this e-mail on
 another device, such as a laptop or PC. It is being investigated how
 to best solve this problem.)
 

--- a/pages/en/issuance-idin.md
+++ b/pages/en/issuance-idin.md
@@ -29,7 +29,7 @@ logs into iDIN, namely:
  * city.
 
 These personal attributes are obtained from the bank of the user.  The
-correctness of the attributes is the bank's responsability. The
+correctness of the attributes is the bank's responsibility. The
 foundation does not check them.
 
 The foundation receives, after permission of the user, these

--- a/pages/en/issuance-socialmedia.md
+++ b/pages/en/issuance-socialmedia.md
@@ -10,7 +10,7 @@ translations:
 ---
 
 Attributes like your name or email address can be added to your IRMA
-app via the sociale media [Facebook](https://www.facebook.com),
+app via the social media [Facebook](https://www.facebook.com),
 [Twitter](https://twitter.com) en [LinkedIn](https://linkedin.com).
 The Privacy by Design foundation is registered with each of these
 parties in order to receive attributes. The foundation digitally signs
@@ -22,10 +22,10 @@ The following attributes can be used.
 
  * **Facebook**: full name, first name, family name, email address,
  date of birth
- * **Twitter**: username, full name, email address, webaddress
+ * **Twitter**: username, full name, email address, web-address
  of one's own Twitter profile
  * **LinkedIn**: full name, first name, family name, email address,
- webaddress of one's own LinkedIn profile.
+ web-address of one's own LinkedIn profile.
 
 The validity period of these social media attributes is *one year*.
 

--- a/pages/en/issuance-surfconext.md
+++ b/pages/en/issuance-surfconext.md
@@ -23,7 +23,7 @@ and can thus obtain attributes about someone who logs in, namely:
 
 These personal attributes are obtained from the institution of the
 user.  The correctness of the attributes is the institution's
-responsability. The foundation does not check them.
+responsibility. The foundation does not check them.
 
 
 The foundation receives, after permission of the user, these
@@ -38,12 +38,12 @@ The validity period of this surfconext credential is *three months*.
 This relatively short time is required, so that people who
 finish their studies, stop working, or leave their (educational)
 institution in some other way, only have a short time period
-in which they can use these credentials. After experation of the
+in which they can use these credentials. After expiration of the
 credential, users have to obtain a new (fresh) credential.
 
 At this stage this attribute issuance is available only for students
 and staff members of a limited number of institutions in higher
-eduction in the Netherlands. Are you studying or working at such an
+education in the Netherlands. Are you studying or working at such an
 institution but does your institution not occur in the list at the <a
 href="https://privacybydesign.foundation/uitgifte/surfnet?action=login">SURFconext
 issuance page</a>? This means that your institution has not "switched

--- a/pages/en/issuance.md
+++ b/pages/en/issuance.md
@@ -56,7 +56,7 @@ Attributes (differs per network): first name, family name, email address, birth 
 Attributes: given name, family name, email address, institution, staff/student, local registration number  
 <a class="button" href="/issuance/surfnet/edugain">
 <img src="/images/edugain.png">Load attributes via eduGAIN</a>  
-Notice: this is an experimental service. We appreciate any feedback at irma 'at' privacybydesign.foundation, preferrably with screenshots if something goes wrong.
+Notice: this is an experimental service. We appreciate any feedback at irma 'at' privacybydesign.foundation, preferably with screenshots if something goes wrong.
 
 ### Attributes for Europe
 
@@ -106,4 +106,4 @@ Attributes: initials, family name, date of birth, gender, address, postal code, 
 Attributes: school and/or study diploma   
 <a class="button" style="cursor: not-allowed;" disabled>
 <img src="/images/diploma-logo.png">Load attributes via DUO</a>  
-**This experimental service has been temporarily disabled due to a change in the diploma documentent by DUO.** We are happy to receive feedback about possible use-cases via irma 'at' privacybydesign.foundation. ([more information](/issuance-diploma), [try anyway](/uitgifte/diploma))
+**This experimental service has been temporarily disabled due to a change in the diploma documentation by DUO.** We are happy to receive feedback about possible use-cases via irma 'at' privacybydesign.foundation. ([more information](/issuance-diploma), [try anyway](/uitgifte/diploma))

--- a/pages/en/people.md
+++ b/pages/en/people.md
@@ -11,7 +11,7 @@ translations:
 ---
 
 The board of the Privacy by Design foundation consists of the people
-listed below. They all fulfil their role in the board in a personal
+listed below. They all fulfill their role in the board in a personal
 capacity and are not being paid for it.
 
  * **Chairman**: Bart Jacobs (b.jacobs 'at' privacybydesign.foundation)
@@ -34,18 +34,18 @@ capacity and are not being paid for it.
  * **Treasurer**:  Jean Popma (j.popma 'at' privacybydesign.foundation) 
 
    [Jean Popma](https://www.linkedin.com/in/jeanpopma) works as
-   projectmanager Applied Security Research at Radboud University
-   Nijmegen; in that role he is responsible for the realisation o
-   fprivacy-friendly systems for the storage and sharing of scientific
+   project manager Applied Security Research at Radboud University
+   Nijmegen; in that role he is responsible for the realization of
+   privacy-friendly systems for the storage and sharing of scientific
    medical date. He has ample experience as ICT-manager and as
    Security Officer within Radboud University.
 
  * Thea van Kemenade (t.vankemenade 'at' privacybydesign.foundation)
    is business development consultant at Radboud Innovation, the
-   centre for business and project development of Radboud
+   center for business and project development of Radboud
    University. Her central role is bringing together public and
    private, often open-innovation, partners for specific projects,
-   organising funding and actually realising and implementing these
+   organizing funding and actually realizing and implementing these
    innovations.
 
  * Tim Vermeulen (t.vermeulen 'at' privacybydesign.foundation) is IT
@@ -61,7 +61,7 @@ capacity and are not being paid for it.
 Sietse Ringers (s.ringers 'at' privacybydesign.foundation) is *chief
 architect* and *lead developer* of the Privacy by
 Design foundation. In addition, the following people are (or have
-been) active in developing software and webpages of the foundation.
+been) active in developing software and web-pages of the foundation.
 
 #### Active developers
 

--- a/pages/en/privacy-policy-en.md
+++ b/pages/en/privacy-policy-en.md
@@ -10,7 +10,7 @@ translations:
 ---
 
 The Privacy by Design foundation processes personal data with the aim
-of realising attribute-based authentication and signatures via the
+of realizing attribute-based authentication and signatures via the
 system [IRMA](/irma-en), an abbreviation for *I Reveal My Attributes*.
 The foundation is responsible for this data processing and in doing so
 abides by the General Data Protection Regulation (GDPR).
@@ -55,14 +55,14 @@ The foundation processes personal data in three different ways.
    purpose is providing an IRMA user insight in the usage of his/her
    own account, associated with the user's email address, in order to
    detect possible abuse and to (subsequently) block the account. With
-   this access to a user's own log data the foundation fulfils its
+   this access to a user's own log data the foundation fulfills its
    obligation to provide users insight in their own data. These log
    data are stored and protected until they are deleted by the
    user. The logs contain only time stamps of actions, together with
    the kind of action that happened, such as *PIN verified* or *IRMA
    session performed*. In particular, these logs do not contain
    personal data, such as attributes, or information about the party
-   to which attributes are revealed, or form which attribes are
+   to which attributes are revealed, or form which attributes are
    received. These log data are not shared with others, unless there
    is a legal obligation to do so. When an IRMA account is terminated,
    or when its data are removed, all these log data are immediately
@@ -72,11 +72,11 @@ The foundation processes personal data in three different ways.
    encounters a serious problem, an error report is made and sent to
    the foundation. These error reports are a critical instrument for
    the foundation in fixing problems and improving the IRMA app.  An
-   error repport never contains user attributes, or data about
+   error report never contains user attributes, or data about
    previous usage of the IRMA app, but only technical data about what
    went wrong and about your phone (for example, IP address, the app
    version number, and the version number of Android or iOS). The
-   foundation removes these reports when they are no longer neccesary,
+   foundation removes these reports when they are no longer necessary,
    or at least within three months.
 
 3. **One time, only temporarily.** At issuance of attributes by the

--- a/pages/en/prizes.md
+++ b/pages/en/prizes.md
@@ -45,11 +45,11 @@ has won with the identity platform IRMA.
 
 <img align="left" src="../images/privacyaward.jpg" alt="Privacy Award"
 style="border:10px solid white; width: 35%; height: 35%"/> The
-foundation [Privacy First](https://privacyfirst.nl/) awarded in janary
+foundation [Privacy First](https://privacyfirst.nl/) awarded in January
 2018 the *Dutch Privacy Award* to the identity platform IRMA. The
 [jury](https://privacyfirst.nl/solutions/evenementen/item/1104-winnaars-nederlandse-privacy-awards-2018.html)
 commends IRMA's privacy by design, its large innovative potential, and
-its potential social impact. The prize is an honourfull recognition of
+its potential social impact. The prize is an honored recognition of
 the IRMA's strong focus on privacy protection. This prize does not
 involves prize money, but it does come with a sculpture, as shown in
 the image on the side.

--- a/pages/en/reviews-en.md
+++ b/pages/en/reviews-en.md
@@ -17,4 +17,4 @@ This page contains privacy and security reviews of the IRMA platform.
    Walree](https://www.ru.nl/english/people/walree-t/) of the
    Law faculty at Nijmegen, and reviewed by Koen Versmissen
    of [Privacy Management Partners](https://www.pmpartners.nl/),
-   dec. 2018.
+   Dec. 2018.

--- a/pages/en/support.md
+++ b/pages/en/support.md
@@ -10,7 +10,7 @@ translations:
   nl: /steun
 ---
 
-The Privacy by Design foundation does not wish to monopolise and sees
+The Privacy by Design foundation does not wish to monopolize and sees
 the development of the identity platform IRMA as a *community effort*
 with possible involvement, cooperation and support from different
 sides and in different ways. Below more information is given about two
@@ -19,7 +19,7 @@ contributions please get [in touch](/contact-en).
 
 ### Contribute to software development
 
-If you, as individual or organisation, wish to contribute to further
+If you, as individual or organization, wish to contribute to further
 development of IRMA software, please contact the *lead developer*
 Sietse Ringers (s.ringers 'at' privacybydesign.foundation).
 Contributions are welcome, for instance, for integration of IRMA
@@ -28,7 +28,7 @@ communication and text processing. For instance, it would be very nice
 to have plugins for checking IRMA signatures in various mail clients
 or office environments. The foundation hopes that such software will
 become freely available, as open source. However, it is also possible
-to build commmercial and/or closed source software on top of the
+to build commercial and/or closed source software on top of the
 (free) IRMA infrastructure.
 
 ### Contribute financially
@@ -40,14 +40,14 @@ infrastructure up and running and to develop and maintain new services
 and software (among which, in particular, the [IRMA
 app](https://privacybydesign.foundation/download/)).
 
-The Privacy by Design foundation is a non-for-profit organisation.
+The Privacy by Design foundation is a non-for-profit organization.
 But it does need funding for its activities. This is where you can
 help, certainly if you appreciate the foundation's activities.
 
 The foundation awards the special status *Friend of the Foundation* or
-*Hero of the Foundation* to companies and other organisations, or
+*Hero of the Foundation* to companies and other organizations, or
 private citizens, that support the foundation with at least
-ten thousand Euro (friends) or hundred thousand Euro (heros).
+ten thousand Euro (friends) or hundred thousand Euro (heroes).
 
 When you are interested in becoming a friend or hero of the
 foundation, please contact the chairman of the foundation (voorzitter
@@ -61,8 +61,8 @@ foundation are:
   continue its activities in the long run.
 
 Friend/hero-ship of the foundation does not give any policy influence:
-the foundation is and remains independent. The foundation wil, if
-needed, support its friends and heros first when operational problems
+the foundation is and remains independent. The foundation will, if
+needed, support its friends and heroes first when operational problems
 arise. Financial contributions will be spent only in line with the
 [goals](https://privacybydesign.foundation/about/) of the foundation.
 The foundation publishes a year report containing a financial

--- a/pages/en/videos-en.md
+++ b/pages/en/videos-en.md
@@ -17,7 +17,7 @@ Some of them are in Dutch.
 ## Videos
 
  * Presentation about Digital Identities at the [Royal
-   Institution](https://www.rigb.org) in London, on feb. 21, 2019, by
+   Institution](https://www.rigb.org) in London, on Feb. 21, 2019, by
    Bart Jacobs.
 
    <div style="text-align:center;margin:1.5em"> <iframe width="560"
@@ -26,7 +26,7 @@ Some of them are in Dutch.
    frameborder="0" allow="autoplay; encrypted-media"
    allowfullscreen></iframe> </div>
 
- * An [OMOOC](https://omooc.nl/) video in Dutch from jan. 2019, about
+ * An [OMOOC](https://omooc.nl/) video in Dutch from Jan. 2019, about
    online identities, developed by the ministry of Internal Affairs of
    The Netherlands, with Wouter Welling, Marleen Stikker, Bart Jacobs
    and Martijn van der Linden.
@@ -37,7 +37,7 @@ Some of them are in Dutch.
    frameborder="0" allow="autoplay; encrypted-media"
    allowfullscreen></iframe> </div>
 
- * At the VNG Fieldlab week (24-28 sept. 2018) in Zwolle [team
+ * At the VNG Fieldlab week (24-28 Sept. 2018) in Zwolle [team
    NLX](https://nlx.io/) had a fridge full of
    [Club-Mate](https://motherboard.vice.com/en_us/article/xywxm7/how-a-german-soda-became-hackers-fuel-of-choice)
    that could be opened only with the right IRMA attribute. The IRMA
@@ -80,7 +80,7 @@ Some of them are in Dutch.
 
    <br>
 
- * At the VNG Fieldlab meeting in Zwolle, 24-28 sept. 2018:
+ * At the VNG Fieldlab meeting in Zwolle, 24-28 Sept. 2018:
 
    <img align="middle" src="/images/irma-drawing.jpg" alt="fieldlab" style="border:10px solid white" >
    <br/>


### PR DESCRIPTION
Just a few spelling and typo corrections for the English language documentation pages.
Also one fixed url in README.md